### PR TITLE
ls.rbを追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,15 +3,15 @@
 
 def main
   files = Dir.glob('*')
-  column_number = 3
-  row_number = (files.size / column_number.to_f).ceil
-  show_file_list(files, column_number, row_number)
+  column_count = 3
+  row_count = (files.size / column_count.to_f).ceil
+  show_file_list(files, column_count, row_count)
 end
 
-def show_file_list(files, column_number, row_number)
-  row_number.times do |r|
-    column_number.times do |c|
-      print files[r + row_number * c].to_s.ljust(18)
+def show_file_list(files, column_count, row_count)
+  row_count.times do |row|
+    column_count.times do |column|
+      print files[row + row_count *column].to_s.ljust(18)
     end
     puts
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,17 +1,19 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+COLUMN_COUNT = 3
+LIST_WIDTH = 18
+
 def main
   files = Dir.glob('*')
-  column_count = 3
-  show_file_list(files, column_count)
+  show_file_list(files, COLUMN_COUNT)
 end
 
 def show_file_list(files, column_count)
   row_count = files.size.ceildiv(column_count)
   row_count.times do |row|
     column_count.times do |column|
-      print files[row + row_count *column].to_s.ljust(18)
+      print files[row + row_count *column].to_s.ljust(LIST_WIDTH)
     end
     puts
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+def main
+  files = Dir.glob('*')
+  column_number = 3
+  row_number = (files.size / column_number.to_f).ceil
+  show_file_list(files, column_number, row_number)
+end
+
+def show_file_list(files, column_number, row_number)
+  row_number.times do |r|
+    column_number.times do |c|
+      print files[r + row_number * c].to_s.ljust(18)
+    end
+    puts
+  end
+end
+
+main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -4,11 +4,11 @@
 def main
   files = Dir.glob('*')
   column_count = 3
-  row_count = (files.size / column_count.to_f).ceil
-  show_file_list(files, column_count, row_count)
+  show_file_list(files, column_count)
 end
 
-def show_file_list(files, column_count, row_count)
+def show_file_list(files, column_count)
+  row_count = files.size.ceildiv(column_count)
   row_count.times do |row|
     column_count.times do |column|
       print files[row + row_count *column].to_s.ljust(18)


### PR DESCRIPTION
以下の仕様を満たすように設計
・オプション以外のコマンドライン引数(パス指定)なしで現在のディレクトリを対象として 
　ls コマンドが実行される 
・二つ以上のメソッドを自分で定義する
・gemを使わずにRubyの標準ライブラリのみで実装する
・表示できる列数を可変にする
・1つのファイル名の表示幅は18