### PR TITLE
「lsコマンドを作る2」の機能を追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,12 +1,23 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 COLUMN_COUNT = 3
 LIST_WIDTH = 18
 
 def main
-  files = Dir.glob('*')
-  show_file_list(files, COLUMN_COUNT)
+  options = {}
+  opts = OptionParser.new
+  opts.on('-a', '--all', 'List all files') { options[:all] = true }
+  opts.parse(ARGV)
+
+  files = if options[:all]
+            Dir.entries('.')
+          else
+            Dir.glob('*')
+          end
+  show_file_list(files.sort, COLUMN_COUNT)
 end
 
 def show_file_list(files, column_count)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -13,7 +13,7 @@ def main
   opts.parse(ARGV)
 
   files = if options[:all]
-            Dir.entries('.')
+            Dir.glob('*', File::FNM_DOTMATCH)
           else
             Dir.glob('*')
           end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -12,11 +12,8 @@ def main
   opts.on('-a', '--all', 'List all files') { options[:all] = true }
   opts.parse(ARGV)
 
-  files = if options[:all]
-            Dir.glob('*', File::FNM_DOTMATCH)
-          else
-            Dir.glob('*')
-          end
+  flags = options[:all] ? File::FNM_DOTMATCH : 0
+  files = Dir.glob('*', flags)
   show_file_list(files.sort, COLUMN_COUNT)
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -24,7 +24,7 @@ def show_file_list(files, column_count)
   row_count = files.size.ceildiv(column_count)
   row_count.times do |row|
     column_count.times do |column|
-      print files[row + row_count *column].to_s.ljust(LIST_WIDTH)
+      print files[row + row_count * column].to_s.ljust(LIST_WIDTH)
     end
     puts
   end


### PR DESCRIPTION
以下の仕様を満たすように設計
・-aまたは--allオプションで、隠しファイルを含めてカレントディレクトリの一覧を表示させる